### PR TITLE
fix: add warning message when get config.json failed

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfunction/functions-framework",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Nodejs functions framework for OpenFunction",
   "main": "index.js",
   "bin": {

--- a/src/openfunction/config.js
+++ b/src/openfunction/config.js
@@ -11,7 +11,8 @@ try {
   config = require(process.cwd() + '/config.json')
 } catch (err) {
   config = {}
-  console.error('get config.json failed: ' + err)
+  console.warn('get config.json failed: ' + err)
+  console.warn('if you want to serve your function in an async way, a right config.json must be provided')
 }
 
 // check user input here to simplify the business logic


### PR DESCRIPTION
if a user chooses to use openfunction as a sync way, a `config.json` is not required

thus when a `config.json` is not found, we should only print warning messages.